### PR TITLE
Quaterniond::w returns const double & instead of double to work with …

### DIFF
--- a/python/core/eigen_types.h
+++ b/python/core/eigen_types.h
@@ -182,10 +182,10 @@ void declareEigenTypes(py::module & m) {
                 return Eigen::Quaterniond::FromTwoVectors(a, b);
             })
 
-        .def("x", (double (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::x)
-        .def("y", (double (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::y)
-        .def("z", (double (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::z)
-        .def("w", (double (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::w)
+        .def("x", (const double&  (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::x)
+        .def("y", (const double&  (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::y)
+        .def("z", (const double&  (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::z)
+        .def("w", (const double&  (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::w)
 
         .def("vec", (const Eigen::VectorBlock<const Eigen::Quaterniond::Coefficients,3> (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::vec)
 


### PR DESCRIPTION
…Eigen CoeffReturnType

Eigen has this new CoeffReturnType typedef which causes build to fail. 
https://eigen.tuxfamily.org/dox/DenseCoeffsBase_8h_source.html
