### PR TITLE
Fixes Eigen quaternion member access

### DIFF
--- a/python/core/eigen_types.h
+++ b/python/core/eigen_types.h
@@ -181,11 +181,10 @@ void declareEigenTypes(py::module & m) {
         .def_static("from_two_vectors", [](Eigen::Matrix<double, 3, 1>& a, Eigen::Matrix<double, 3, 1>& b) {
                 return Eigen::Quaterniond::FromTwoVectors(a, b);
             })
-
-        .def("x", (double (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::x)
-        .def("y", (double (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::y)
-        .def("z", (double (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::z)
-        .def("w", (double (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::w)
+        .def("x", [](const Eigen::Quaterniond& q) { return q.x(); })
+        .def("y", [](const Eigen::Quaterniond& q) { return q.y(); })
+        .def("z", [](const Eigen::Quaterniond& q) { return q.z(); })
+        .def("w", [](const Eigen::Quaterniond& q) { return q.w(); })
 
         .def("vec", (const Eigen::VectorBlock<const Eigen::Quaterniond::Coefficients,3> (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::vec)
 


### PR DESCRIPTION
Ubuntu 20.04 - Eigen 3.3.7


I encountered the same problem on Ubuntu 20.04. In my case, I could build the library by changing:

```cpp
        .def("x", (double (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::x)
        .def("y", (double (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::y)
        .def("z", (double (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::z)
        .def("w", (double (Eigen::Quaterniond::*) () const) &Eigen::Quaterniond::w)
```

in ```g2opy/python/core/eigen_types.h``` to:

```cpp
        .def("x", [](const Eigen::Quaterniond& q) { return q.x(); })
        .def("y", [](const Eigen::Quaterniond& q) { return q.y(); })
        .def("z", [](const Eigen::Quaterniond& q) { return q.z(); })
        .def("w", [](const Eigen::Quaterniond& q) { return q.w(); })
```

_Originally posted by @koide3 in https://github.com/uoip/g2opy/issues/46#issuecomment-704190419_